### PR TITLE
iBeacon / Geofencing compatibility, and configurable "Anyone" and "No One" sensors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # homebridge-people
-This is a plugin for homebridge. It monitors who is at home, based on their smartphone being seen on the network recently.
+This is a plugin for [homebridge](https://github.com/nfarina/homebridge). It monitors who is at home, based on their smartphone being seen on the network recently.
+
+It can also receive webhooks sent by location-aware mobile apps (such as [Locative](https://my.locative.io), which can use iBeacons and geofencing to provide faster and more accurate location information.
 
 # Installation
 
-1. Install homebridge (if not already installed) using: npm install -g homebridge
-2. Install this plugin using: npm install -g homebridge-people
+1. Install homebridge (if not already installed) using: `npm install -g homebridge`
+2. Install this plugin using: `npm install -g homebridge-people`
 3. Update your configuration file. See below for a sample.
 
 # Configuration
@@ -12,14 +14,16 @@ This is a plugin for homebridge. It monitors who is at home, based on their smar
 ```
 "accessories": [
 	{
-    "accessory" : "people",
-    "name" : "People",
-    "people" : [
-      { "name" : "Pete", "target" : "PetesiPhone" },
-      { "name" : "Someone Else", "target" : "192.168.1.68" }
-    ],
-    "threshold" : 15
-  }
+  "accessory" : "people",
+  "name" : "People",
+  "people" : [
+   { "name" : "Pete", "target" : "PetesiPhone" },
+   { "name" : "Someone Else", "target" : "192.168.1.68" }
+  ],
+  "threshold" : 15,
+  "anyone_sensor" : true,
+  "noone_sensor" : false
+ }
 ],
 ```
 
@@ -27,14 +31,29 @@ This is a plugin for homebridge. It monitors who is at home, based on their smar
 
 # How it works
 * When started homebridge-people will continually ping the IP address associated with each person defined in config.json.
+* With an iBeacon or geofencing smartphone app, you can configure a HTTP push to trigger when you enter and exit your 'home' region. This data will be combined with the IP ping function to give this plugin more precise presence data.
 * When a ping is successful the current timestamp is logged to a file (seen.db.json)
 * When a Homekit enabled app looks up the state of a person, the last seen time for that persons device is compared to the current time minus ```threshold``` minutes, and if it is greater assumes that the person is active.
 
-# Accuracy
-This plugin requires that the devices being monitored are connected to the network.  iPhones (and I expect others) deliberately disconnect from the network once the screen is turned off to save power, meaning just because the device isn't connected, it doesn't mean that the devices owner isn't at home.  Fortunately, iPhones (and I expect others) periodically reconnect to the network to check for updates, emails, etc.  This plugin works by keeping track of the last time a device was seen, and comparing that to a threshold value (in minutes).
+# 'Anyone' and 'No One' sensors
+Some HomeKit automations need to happen when "anyone" is home or when "no one" is around, but the default Home app makes this difficult. homebridge-people can automatically create additional sensors called "Anyone" and "No One" to make these automations very easy.
 
-From a _very_ limited amount of testing, I've found that a threshold of 15 minutes seems to work well for the phones that I have around, but for different phones this may or may not work.  The threshold can be configured in the ```.homebridge/config.json``` file.
+For example, you might want to run your "Arrive Home" scene when _Anyone_ gets home. Or run "Leave Home" when _No One_ is home.
+
+These sensors can be enabled by adding `"anyone_sensor" : true` and `"noone_sensor" : true` to your `config.yml` file.
+
+# Accuracy
+This plugin requires that the devices being monitored are connected to the network. iPhones (and I expect others) deliberately disconnect from the network once the screen is turned off to save power, meaning just because the device isn't connected, it doesn't mean that the devices owner isn't at home. Fortunately, iPhones (and I expect others) periodically reconnect to the network to check for updates, emails, etc. This plugin works by keeping track of the last time a device was seen, and comparing that to a threshold value (in minutes).
+
+From a _very_ limited amount of testing, I've found that a threshold of 15 minutes seems to work well for the phones that I have around, but for different phones this may or may not work. The threshold can be configured in the ```.homebridge/config.json``` file.
+
+Additionally, if you're using a location-aware mobile app to range for iBeacons and geofences, this plugin can receive a HTTP push from the app to immediately see you as present or not present when you physically enter or exit your desired region. This is particularly useful for "Arrive Home" and "Depart Home" HomeKit automations which ideally happen faster than every 15 minutes.
+
+# Pairing with a location-aware mobile app
+Apps like [Locative](https://my.locative.io) range for iBeacons and geofences by using core location APIs available on your smartphone. With bluetooth and location services turned on, these apps can provide an instantaneous update when you enter and exit a desired region.
+
+To use this plugin with one of these apps, configure your region and set the HTTP push to `http://youripaddress:51828/?[name]&state=true` for arrival, and `http://youripaddress:51828/?[name]&state=false` for departure, where `[name]` is the name of the person the device belongs to as specified in your config under `people`. *Note:* you may need to enable port forwarding on your router to accomplish this.
 
 # Notes
 ## Running on a raspberry pi as non 'pi' user
-On some versions of raspbian, users are not able to use the ping program by default.  If none of your devices show online try running ```sudo chmod u+s /bin/ping```.  Thanks to oberstmueller for the tip.
+On some versions of raspbian, users are not able to use the ping program by default. If none of your devices show online try running ```sudo chmod u+s /bin/ping```. Thanks to oberstmueller for the tip.

--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ function PeopleAccessory(log, config) {
   this.log = log;
   this.name = config['name'];
   this.people = config['people'];
-  this.anyone_sensor = config['anyone_sensor'];
-  this.noone_sensor = config['noone_sensor'];
+  this.anyone_sensor = config['anyone_sensor'] || false;
+  this.noone_sensor = config['noone_sensor'] || false;
   this.threshold = config['threshold'];
   this.webhook_port = config["webhook_port"] || 51828;
   this.services = [];

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ function PeopleAccessory(log, config) {
   this.log = log;
   this.name = config['name'];
   this.people = config['people'];
+  this.anyone_sensor = config['anyone_sensor'];
+  this.noone_sensor = config['noone_sensor'];
   this.threshold = config['threshold'];
   this.webhookPort = config["webhook_port"] || 51828;
   this.services = [];
@@ -44,27 +46,31 @@ function PeopleAccessory(log, config) {
     this.services.push(service);
   }.bind(this));
 
-  //Setup an ANYONE OccupancySensor
-  var service = new Service.OccupancySensor('ANYONE', 'ANYONE');
-  service.target = 'ANYONE';
-  service
-    .getCharacteristic(Characteristic.OccupancyDetected)
-    .on('get', this.getAnyoneState.bind(this));
+  if(this.anyone_sensor) {
+    //Setup an ANYONE OccupancySensor
+    var service = new Service.OccupancySensor('ANYONE', 'ANYONE');
+    service.target = 'ANYONE';
+    service
+      .getCharacteristic(Characteristic.OccupancyDetected)
+      .on('get', this.getAnyoneState.bind(this));
 
-  this.services.push(service);
+    this.services.push(service);
 
-  this.populateStateCache();
+    this.populateStateCache();
+  }
 
-  //Setup an NO ONE OccupancySensor
-  var service = new Service.OccupancySensor('NO ONE', 'NO ONE');
-  service.target = 'NO ONE';
-  service
-    .getCharacteristic(Characteristic.OccupancyDetected)
-    .on('get', this.getNoOneState.bind(this));
+  if(this.noone_sensor) {
+    //Setup an NO ONE OccupancySensor
+    var service = new Service.OccupancySensor('NO ONE', 'NO ONE');
+    service.target = 'NO ONE';
+    service
+      .getCharacteristic(Characteristic.OccupancyDetected)
+      .on('get', this.getNoOneState.bind(this));
 
-  this.services.push(service);
+    this.services.push(service);
 
-  this.populateStateCache();
+    this.populateStateCache();
+  }
 
   //Start pinging the hosts
   this.pingHosts();

--- a/index.js
+++ b/index.js
@@ -47,9 +47,9 @@ function PeopleAccessory(log, config) {
   }.bind(this));
 
   if(this.anyone_sensor) {
-    //Setup an ANYONE OccupancySensor
-    var service = new Service.OccupancySensor('ANYONE', 'ANYONE');
-    service.target = 'ANYONE';
+    //Setup an Anyone OccupancySensor
+    var service = new Service.OccupancySensor('Anyone', 'Anyone');
+    service.target = 'Anyone';
     service
       .getCharacteristic(Characteristic.OccupancyDetected)
       .on('get', this.getAnyoneState.bind(this));
@@ -60,9 +60,9 @@ function PeopleAccessory(log, config) {
   }
 
   if(this.noone_sensor) {
-    //Setup an NO ONE OccupancySensor
-    var service = new Service.OccupancySensor('NO ONE', 'NO ONE');
-    service.target = 'NO ONE';
+    //Setup an No One OccupancySensor
+    var service = new Service.OccupancySensor('No One', 'No One');
+    service.target = 'No One';
     service
       .getCharacteristic(Characteristic.OccupancyDetected)
       .on('get', this.getNoOneState.bind(this));
@@ -129,13 +129,13 @@ function PeopleAccessory(log, config) {
               var service = this.getServiceForTarget(target);
               service.getCharacteristic(Characteristic.OccupancyDetected).setValue(newState);
 
-              //Trigger an update to the Homekit service associated with 'ANYONE'
-              var anyoneService = this.getServiceForTarget('ANYONE');
+              //Trigger an update to the Homekit service associated with 'Anyone'
+              var anyoneService = this.getServiceForTarget('Anyone');
               var anyoneState = this.getAnyoneStateFromCache();
               anyoneService.getCharacteristic(Characteristic.OccupancyDetected).setValue(anyoneState);
 
-              //Trigger an update to the Homekit service associated with 'NO ONE'
-              var noOneService = this.getServiceForTarget('NO ONE');
+              //Trigger an update to the Homekit service associated with 'No One'
+              var noOneService = this.getServiceForTarget('No One');
               var noOneState = this.getNoOneStateFromCache();
               noOneService.getCharacteristic(Characteristic.OccupancyDetected).setValue(noOneState);
             }
@@ -247,13 +247,13 @@ PeopleAccessory.prototype.pingHosts = function() {
         var service = this.getServiceForTarget(target);
         service.getCharacteristic(Characteristic.OccupancyDetected).setValue(newState);
 
-        //Trigger an update to the Homekit service associated with 'ANYONE'
-        var anyoneService = this.getServiceForTarget('ANYONE');
+        //Trigger an update to the Homekit service associated with 'Anyone'
+        var anyoneService = this.getServiceForTarget('Anyone');
         var anyoneState = this.getAnyoneStateFromCache();
         anyoneService.getCharacteristic(Characteristic.OccupancyDetected).setValue(anyoneState);
 
-        //Trigger an update to the Homekit service associated with 'NO ONE'
-        var noOneService = this.getServiceForTarget('NO ONE');
+        //Trigger an update to the Homekit service associated with 'No One'
+        var noOneService = this.getServiceForTarget('No One');
         var noOneState = this.getNoOneStateFromCache();
         noOneService.getCharacteristic(Characteristic.OccupancyDetected).setValue(noOneState);
       }

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function PeopleAccessory(log, config) {
   this.anyone_sensor = config['anyone_sensor'];
   this.noone_sensor = config['noone_sensor'];
   this.threshold = config['threshold'];
-  this.webhookPort = config["webhook_port"] || 51828;
+  this.webhook_port = config["webhook_port"] || 51828;
   this.services = [];
   this.storage = require('node-persist');
   this.stateCache = [];
@@ -145,8 +145,8 @@ function PeopleAccessory(log, config) {
         response.end();
       }
     }).bind(this));
-  }).bind(this)).listen(this.webhookPort);
-  this.log("WebHook: Started server on port '%s'.", this.webhookPort);
+  }).bind(this)).listen(this.webhook_port);
+  this.log("WebHook: Started server on port '%s'.", this.webhook_port);
 }
 
 PeopleAccessory.prototype.populateStateCache = function() {

--- a/index.js
+++ b/index.js
@@ -75,6 +75,12 @@ function PeopleAccessory(log, config) {
   //Start pinging the hosts
   this.pingHosts();
 
+  //
+  // HTTP webserver code influenced by benzman81's great
+  // homebridge-http-webhooks homebridge plugin.
+  // https://github.com/benzman81/homebridge-http-webhooks
+  //
+
   // Start the HTTP webserver
   http.createServer((function(request, response) {
     var theUrl = request.url;

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function PeopleAccessory(log, config) {
         response.end();
       }
       else {
-        var sensor = theUrlParams.sensor;
+        var sensor = theUrlParams.sensor.toLowerCase();
         var state = (theUrlParams.state == "true");
         var responseBody = {
           success: true


### PR DESCRIPTION
Adds three enhancements:
1. Adds a "No One" sensor, which works opposite to "Anyone" – for users of the Home app in iOS 10, it's not possible to create automations for "if 'Anyone' is _not_ triggered."
2. Adds a HTTP server which listens for a webhook from a iBeacon / geofencing mobile app like Locative. This functionality bypasses the `threshold` feature and provides immediate presence data if a user enters or exits a region defined in their mobile app. It's quite a bit faster than the IP ping, which needs ~15 minutes of smoothing to provide accurate data. The iBeacon sensing code works alongside the IP ping to give not only accurate data, but incredibly fast enter/exit data to enable "Arrive Home" and "Depart Home" automations that happen instantly, instead of potentially after 15 minutes.
3. The ability to enable or disable "Anyone" and "No One" from `config.yml` (with documentation).

Fixes #18 and possibly fixes #2 -- open to your interpretation :)
