### PR TITLE
Config Sensor names for Anyone and No One

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ It can also receive webhooks sent by location-aware mobile apps (such as [Locati
         "platform": "People",
         "threshold" : 15,
         "anyoneSensor" : true,
+        "anyoneSensorName" : "Anyone",
         "nooneSensor" : false,
+        "nooneSensorName": "No One",
         "webhookPort": 51828,
         "cacheDirectory": "./.node-persist/storage",
         "pingInterval": 10000,
@@ -48,7 +50,9 @@ It can also receive webhooks sent by location-aware mobile apps (such as [Locati
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `threshold`                | optional, in minutes, default: 15                                                                                                                                                            |
 | `anyoneSensor`             | optional, default: true                                                                                                                                                                      |
+| `anyoneSensorName`         | optional, default: "Anyone"                                                                                                                                                                  |
 | `nooneSensor`              | optional, default: false                                                                                                                                                                     |
+| `nooneSensorName`          | optional, default: "No One"                                                                                                                                                                  |
 | `webhookPort`              | optional, default: 51828                                                                                                                                                                     |
 | `cacheDirectory`           | optional, default: "./.node-persist/storage"                                                                                                                                                 |
 | `pingInterval`             | optional, in milliseconds, default: 10000, if set to -1 than the ping mechanism will not be used                                                                                             |
@@ -63,7 +67,7 @@ It can also receive webhooks sent by location-aware mobile apps (such as [Locati
 * When a Homekit enabled app looks up the state of a person, the last seen time for that persons device is compared to the current time minus ```threshold``` minutes, and if it is greater assumes that the person is active.
 
 # 'Anyone' and 'No One' sensors
-Some HomeKit automations need to happen when "anyone" is home or when "no one" is around, but the default Home app makes this difficult. homebridge-people can automatically create additional sensors called "Anyone" and "No One" to make these automations very easy.
+Some HomeKit automations need to happen when "anyone" is home or when "no one" is around, but the default Home app makes this difficult. homebridge-people can automatically create additional sensors called "Anyone" and "No One" (or custom names) to make these automations very easy.
 
 For example, you might want to run your "Arrive Home" scene when _Anyone_ gets home. Or run "Leave Home" when _No One_ is home.
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ function PeoplePlatform(log, config){
     this.log = log;
     this.threshold = config['threshold'] || 15;
     this.anyoneSensor = config['anyoneSensor'] || true;
+    if (config['anyoneSensorName']) { SENSOR_ANYONE = config['anyoneSensorName']; }
     this.nooneSensor = config['nooneSensor'] || false;
+    if (config['nooneSensorName']) { SENSOR_NOONE = config['nooneSensorName']; }
     this.webhookPort = config["webhookPort"] || 51828;
     this.cacheDirectory = config["cacheDirectory"] || HomebridgeAPI.user.persistPath();
     this.pingInterval = config["pingInterval"] || 10000;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-people",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Homebridge plugin that provides details of who is in a Home",
   "keywords": [
     "homebridge-plugin"


### PR DESCRIPTION
This makes it easier to automatically set a default name for the Anyone and No One sensors.
Good for multi-language support.
I personally wrote it so that as a joke, No One defaults to my cat's name followed by -Alone.