### PR TITLE
use updateValue to enable automation

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ PeopleAccessory.prototype.setNewState = function(newState) {
     var oldState = this.stateCache;
     if (oldState != newState) {
         this.stateCache = newState;
-        this.service.getCharacteristic(Characteristic.OccupancyDetected).setValue(newState);
+        this.service.getCharacteristic(Characteristic.OccupancyDetected).updateValue(newState);
 
         if(this.platform.peopleAnyOneAccessory) {
             this.platform.peopleAnyOneAccessory.refreshState();
@@ -318,7 +318,7 @@ PeopleAllAccessory.prototype.getAnyoneStateFromCache = function() {
 }
 
 PeopleAllAccessory.prototype.refreshState = function() {
-    this.service.getCharacteristic(Characteristic.OccupancyDetected).setValue(this.getStateFromCache());
+    this.service.getCharacteristic(Characteristic.OccupancyDetected).updateValue(this.getStateFromCache());
 }
 
 PeopleAllAccessory.prototype.getServices = function() {


### PR DESCRIPTION
setValue doesn't actively push changes to hubs (as Apple TV or iPads). updateValue is needed to do so, ensuring that the accessories can be used as triggers for automation.