### PR TITLE
Fix for anyoneSensor being set to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function(homebridge) {
 function PeoplePlatform(log, config){
     this.log = log;
     this.threshold = config['threshold'] || 15;
-    this.anyoneSensor = config['anyoneSensor'] || true;
+    this.anyoneSensor = ((typeof(config['anyoneSensor']) != "undefined" && config['anyoneSensor'] !== null)?config['anyoneSensor']:true);
     this.nooneSensor = config['nooneSensor'] || false;
     this.webhookPort = config["webhookPort"] || 51828;
     this.cacheDirectory = config["cacheDirectory"] || HomebridgeAPI.user.persistPath();


### PR DESCRIPTION
Currently if you set anyoneSensor to false, the if statement in the defaults will set it to true:
if is set X, then Y = X
Because the "is set" part returns false (as set in config) it therefore thinks it's not set, and sets the default (in this case true).

Meaning if you set anyoneSensor: false, anyoneSensor is set to true.

This should fix it. Relating to #78 and potential proper fix for #88