### PR TITLE
Add Room Name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ It can also receive webhooks sent by location-aware mobile apps (such as [Locati
 | `anyoneSensor`             | optional, default: true                                                                                                                                                                      |
 | `nooneSensor`              | optional, default: false                                                                                                                                                                     |
 | `webhookPort`              | optional, default: 51828                                                                                                                                                                     |
+| `roomName`                 | optional, add a room name to AnyOne and No One sensors, default: ""                                                                                                                                                                        |
+
 | `cacheDirectory`           | optional, default: "./.node-persist/storage"                                                                                                                                                 |
 | `pingInterval`             | optional, in milliseconds, default: 10000, if set to -1 than the ping mechanism will not be used                                                                                             |
 | `ignoreReEnterExitSeconds` | optional, in minutes, default: 0, if set to 0 than every enter/exit will trigger state change otherwise the state will only change if no re-enter/exit occurs in specified number of seconds |

--- a/index.js
+++ b/index.js
@@ -32,9 +32,18 @@ function PeoplePlatform(log, config){
     this.pingInterval = config["pingInterval"] || 10000;
     this.ignoreReEnterExitSeconds = config["ignoreReEnterExitSeconds"] || 0;
     this.people = config['people'];
+    this.roomName = config["roomName"] || "";
     this.storage = require('node-persist');
     this.storage.initSync({dir:this.cacheDirectory});
     this.webhookQueue = [];
+
+    if (this.roomName) {
+        SENSOR_ANYONE = 'Anyone' + " @ " + this.roomName;
+        SENSOR_NOONE = 'No One' + " @ " +  this.roomName;
+    } else {
+        SENSOR_ANYONE = 'Anyone';
+        SENSOR_NOONE = 'No One';
+    }
 }
 
 PeoplePlatform.prototype = {


### PR DESCRIPTION
I add a new config called 'roomName', which is basically adding room name to Anyone and No One sensors. It will be useful if users would like to setup more than one People platform in homebridge for multiple rooms. For now it is impossible due to duplicated Anyone and No One sensors with same name (and therefore same UUID).