### PR TITLE
Allow disabling anyone sensor

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function(homebridge) {
 function PeoplePlatform(log, config){
     this.log = log;
     this.threshold = config['threshold'] || 15;
-    this.anyoneSensor = config['anyoneSensor'] || true;
+    this.anyoneSensor = typeof config['anyoneSensor'] !== 'undefined' ? config['anyoneSensor'] : true;
     this.nooneSensor = config['nooneSensor'] || false;
     this.webhookPort = config["webhookPort"] || 51828;
     this.cacheDirectory = config["cacheDirectory"] || HomebridgeAPI.user.persistPath();


### PR DESCRIPTION
Currently, if the value of `anyoneSensor` is `false`, it gets defaulted to `true`. This commit fixes that with a slightly more advanced type check.